### PR TITLE
Fixed Warnings for global Vars.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -104,7 +104,7 @@ minetest.register_tool( "replacer:replacer",
           return nil;
        end
 
-       local pos  = minetest.get_pointed_thing_position( pointed_thing, under );
+       local pos  = minetest.get_pointed_thing_position( pointed_thing, false ); -- node under
        local node = minetest.get_node_or_nil( pos );
        
        --minetest.chat_send_player( name, "  Target node: "..minetest.serialize( node ).." at pos "..minetest.serialize( pos ).."."); 
@@ -124,7 +124,7 @@ minetest.register_tool( "replacer:replacer",
 
     on_use = function(itemstack, user, pointed_thing)
 
-       return replacer.replace( itemstack, user, pointed_thing, above );
+       return replacer.replace( itemstack, user, pointed_thing, false );
     end,
 })
 


### PR DESCRIPTION
I've fixed two Warnings, because you use 2 Vars (above and under), they neither exists in local or global.