### PR TITLE
Use node def to identify nodes that cannot be placed to

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -221,14 +221,8 @@ replacer.replace = function( itemstack, user, pointed_thing, mode )
 
 
           -- give the player the item by simulating digging if possible
-          if(   node.name ~= "air" 
-            and node.name ~= "ignore"
-            and node.name ~= "default:lava_source" 
-            and node.name ~= "default:lava_flowing"
-	    and node.name ~= "default:river_water_source"
-	    and node.name ~= "default:river_water_flowing"
-            and node.name ~= "default:water_source"
-            and node.name ~= "default:water_flowing" ) then
+          local node_def = minetest.registered_nodes[node.name]
+          if node_def and not node_def.buildable_to then
 
              minetest.node_dig( pos, node, user );
 


### PR DESCRIPTION
This makes it possible to build with a right-click using the replacer on the vacuum node from BuckarooBanzay's [vacuum mod](https://forum.minetest.net/viewtopic.php?f=9&t=20195).

Without this, the replacer fails to dig the node and you get the message `"Replacing 'vacuum:vacuum' with 'default:gravel 0 0' failed. Unable to remove old node."` (for example).

If you don't like hard-coding non-default node names, we can add an API for other mods to register air-like nodes instead.